### PR TITLE
refactor: RefreshToken PK를 다이어그램에 맞게 변경, 약 조회 시 이름의 일부만 포함되어도 검색

### DIFF
--- a/src/main/java/com/yakbang/server/entity/RefreshToken.java
+++ b/src/main/java/com/yakbang/server/entity/RefreshToken.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class RefreshToken {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
     @Column(nullable = false, length = 500)
@@ -23,6 +22,7 @@ public class RefreshToken {
     private LocalDateTime expiryDate;
 
     @OneToOne
+    @MapsId
     @JoinColumn(name = "user_id", unique = true)
     private User user;
 

--- a/src/main/java/com/yakbang/server/repository/MedicineRepository.java
+++ b/src/main/java/com/yakbang/server/repository/MedicineRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MedicineRepository extends JpaRepository<Medicine, Long> {
     Medicine findBySerial(String serial);
     Medicine findByName(String name);
+    Medicine findByNameContaining(String name);
 }

--- a/src/main/java/com/yakbang/server/service/MedicationService.java
+++ b/src/main/java/com/yakbang/server/service/MedicationService.java
@@ -121,7 +121,7 @@ public class MedicationService {
     public ResponseEntity<DefaultResponse> getMedication(User user, String medicineName) {
         List<String> response = new ArrayList<>();
 
-        Medicine medicine = medicineRepository.findByName(medicineName);
+        Medicine medicine = medicineRepository.findByNameContaining(medicineName);
         if (medicine == null) {
             return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 약을 찾을 수 없습니다."),
                     HttpStatus.NOT_FOUND);


### PR DESCRIPTION
 - RefreshToken PK를 User의 PK인 userId를 FK로 가져와 사용하도록 변경
 - 약 조회 시에, 약 이름의 일부만 포함되어도 검색 가능하도록 변경