### PR TITLE
refactor: 비밀번호 변경 API에서 토큰 대신 사용자 아이디를 통해 변경하도록 수정

### DIFF
--- a/src/main/java/com/yakbang/server/controller/UserController.java
+++ b/src/main/java/com/yakbang/server/controller/UserController.java
@@ -1,10 +1,7 @@
 package com.yakbang.server.controller;
 
 import com.yakbang.server.dto.etc.CustomUserDetails;
-import com.yakbang.server.dto.request.AddDetailRequest;
-import com.yakbang.server.dto.request.MyPageRequest;
-import com.yakbang.server.dto.request.SignInRequest;
-import com.yakbang.server.dto.request.SignUpRequest;
+import com.yakbang.server.dto.request.*;
 import com.yakbang.server.service.ChatService;
 import com.yakbang.server.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -62,8 +59,8 @@ public class UserController {
 
     // 비밀번호 변경
     @PatchMapping("/password")
-    public ResponseEntity changePassword(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody Map<String, String> passwordMap) {
-        return userService.changePassword(userDetails.getUser(), passwordMap.get("password"));
+    public ResponseEntity changePassword(@RequestBody PasswordRequest request) {
+        return userService.changePassword(request);
     }
 
     // 상세정보 등록

--- a/src/main/java/com/yakbang/server/dto/request/PasswordRequest.java
+++ b/src/main/java/com/yakbang/server/dto/request/PasswordRequest.java
@@ -1,0 +1,6 @@
+package com.yakbang.server.dto.request;
+
+public record PasswordRequest(
+        String identity,
+        String password
+) {}

--- a/src/main/java/com/yakbang/server/service/UserService.java
+++ b/src/main/java/com/yakbang/server/service/UserService.java
@@ -1,10 +1,7 @@
 package com.yakbang.server.service;
 
 import com.yakbang.server.context.StatusCode;
-import com.yakbang.server.dto.request.MyPageRequest;
-import com.yakbang.server.dto.request.SignInRequest;
-import com.yakbang.server.dto.request.SignUpRequest;
-import com.yakbang.server.dto.request.AddDetailRequest;
+import com.yakbang.server.dto.request.*;
 import com.yakbang.server.dto.response.CheckUsernameReponse;
 import com.yakbang.server.dto.response.DefaultResponse;
 import com.yakbang.server.dto.response.MyPageResponse;
@@ -154,9 +151,12 @@ public class UserService {
     }
 
     // 비밀번호 변경
-    public ResponseEntity<DefaultResponse> changePassword(User user, String password) {
+    public ResponseEntity<DefaultResponse> changePassword(PasswordRequest request) {
+        // 사용자 검색
+        User user = userRepository.findByIdentity(request.identity());
+
         // 비밀번호 인코딩해서 변경하기
-        user.setPassword(passwordEncoder.encode(password));
+        user.setPassword(passwordEncoder.encode(request.password()));
         userRepository.save(user);
 
         return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "비밀번호 변경 성공"),


### PR DESCRIPTION
refactor: 비밀번호 변경 API 명세서 수정에 따른 변화 적용
 - 토큰 대신 사용자 아이디를 받아 비밀번호를 변경하도록 수정